### PR TITLE
Fix Vagrant SSH Access

### DIFF
--- a/MacBox.pkgproj
+++ b/MacBox.pkgproj
@@ -452,11 +452,27 @@
 						<key>GID</key>
 						<integer>0</integer>
 						<key>PATH</key>
-						<string>build/admin.sh</string>
+						<string>build/authorized_keys</string>
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>600</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>501</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
+						<string>build/group.sh</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -468,11 +484,43 @@
 						<key>GID</key>
 						<integer>0</integer>
 						<key>PATH</key>
+						<string>build/id_rsa</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>600</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>501</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
+						<string>build/id_rsa.pub</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>644</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>501</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
 						<string>build/loginwindow_home.sh</string>
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -488,7 +536,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -504,7 +552,39 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>0</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
+						<string>build/screensaver_host.sh</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>755</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>0</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
+						<string>build/screensaver_root.sh</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -520,7 +600,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -536,7 +616,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -552,7 +632,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -568,7 +648,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -584,7 +664,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -600,7 +680,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>
@@ -616,7 +696,7 @@
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>
-						<integer>420</integer>
+						<integer>755</integer>
 						<key>TYPE</key>
 						<integer>3</integer>
 						<key>UID</key>

--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,27 @@ build/Install\ macOS.cdr.sum: build/Install\ macOS.cdr
 	@printf '${BLD}${YLW}$$${RST} '
 	sha256sum build/Install\ macOS.cdr > build/Install\ macOS.cdr.sum
 
-build/user.sh build/admin.sh build/SetupAssistant.sh build/loginwindow_home.sh build/loginwindow_root.sh build/kcpassword: make.py build/...
+build/authorized_keys:
+	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'
+	@printf '${BLD}${YLW}$$${RST} '
+	wget -O build/authorized_keys https://raw.githubusercontent.com/hashicorp/vagrant/HEAD/keys/vagrant.pub
+
+build/id_rsa:
+	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'
+	@printf '${BLD}${YLW}$$${RST} '
+	wget -O build/id_rsa https://raw.githubusercontent.com/hashicorp/vagrant/HEAD/keys/vagrant
+
+build/id_rsa.pub:
+	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'
+	@printf '${BLD}${YLW}$$${RST} '
+	wget -O build/id_rsa.pub https://raw.githubusercontent.com/hashicorp/vagrant/HEAD/keys/vagrant.pub
+
+build/user.sh build/group.sh build/screensaver_root.sh build/screensaver_host.sh build/SetupAssistant.sh build/loginwindow_root.sh build/loginwindow_home.sh build/kcpassword: make.py build/...
 	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'
 	@printf '${BLD}${YLW}$$${RST} '
 	python3 make.py
 
-build/MacBox.pkg: MacBox.pkgproj postinstall.sh setup.sh jailbreak.sh logouthook.sh build/user.sh build/admin.sh build/SetupAssistant.sh build/loginwindow_home.sh build/loginwindow_root.sh build/kcpassword
+build/MacBox.pkg: MacBox.pkgproj postinstall.sh setup.sh jailbreak.sh logouthook.sh build/authorized_keys build/id_rsa build/id_rsa.pub build/user.sh build/group.sh build/screensaver_root.sh build/screensaver_host.sh build/SetupAssistant.sh build/loginwindow_root.sh build/loginwindow_home.sh build/kcpassword
 	@printf '${BLD}${RED}make: *** [$@]${RST}${EOL}'
 	@printf '${BLD}${YLW}$$${RST} '
 	packagesbuild -v MacBox.pkgproj

--- a/macbox.pkr.hcl
+++ b/macbox.pkr.hcl
@@ -110,10 +110,10 @@ source "vmware-iso" "macbox" {
   // host_port_max = 4444
   // skip_nat_mapping = false
   // ...
-  ssh_username = "user"
-  ssh_password = "pass"
+  ssh_username = "vagrant"
+  ssh_password = "vagrant"
   // ...
-  ssh_timeout = "90m"
+  ssh_timeout = "30m"
   // ...
 
   # Boot Configuration
@@ -147,7 +147,7 @@ build {
 
     // post-processor "vagrant-cloud" {
     //   access_token = "${var.cloud_token}"
-    //   box_tag      = "hashicorp/precise64"
+    //   box_tag      = "incognia/macos"
     //   version      = "${local.version}"
     // }
   }

--- a/setup.sh
+++ b/setup.sh
@@ -1,38 +1,49 @@
 #!/bin/sh
 set -ex
 
+PEDPLIST="$(mktemp -d)/IOPlatformExpertDevice.plist"
+ioreg -a -c IOPlatformExpertDevice -d 2 > "${PEDPLIST}"
+
+HOSTUUID="$(/usr/libexec/PlistBuddy -c 'Print :IORegistryEntryChildren:0:IOPlatformUUID' "${PEDPLIST}")"
+
+DOMAIN="${VOLUME}/System/Library/User Template/Non_localized/Library/Preferences/ByHost/com.apple.screensaver.${HOSTUUID}"
+. ./screensaver_host.sh
+
 DOMAIN="${VOLUME}/System/Library/User Template/Non_localized/Library/Preferences/com.apple.SetupAssistant"
 . ./SetupAssistant.sh
 
 if [ -z "${VOLUME}" ]
 then
-    sysadminctl -addUser user -password pass -admin
-    # dscl . -create /Users/user
-    # dscl . -create /Users/user GeneratedUID 00000000-AAAA-BBBB-CCCC-DDDDEEEEFFFF
-    # dscl . -create /Users/user NFSHomeDirectory /Users/user
-    # dscl . -create /Users/user PrimaryGroupID 20
-    # dscl . -create /Users/user RealName User
-    # dscl . -create /Users/user UniqueID 501
-    # dscl . -create /Users/user UserShell /bin/zsh
-    # dscl . -passwd /Users/user pass
+    sysadminctl -addUser vagrant -fullName Vagrant -UID 501 -password vagrant -admin
+    # dscl . -create /Users/vagrant
+    # dscl . -create /Users/vagrant GeneratedUID 00000000-AAAA-BBBB-CCCC-DDDDEEEEFFFF
+    # dscl . -create /Users/vagrant NFSHomeDirectory /Users/vagrant
+    # dscl . -create /Users/vagrant PrimaryGroupID 20
+    # dscl . -create /Users/vagrant RealName Vagrant
+    # dscl . -create /Users/vagrant UniqueID 501
+    # dscl . -create /Users/vagrant UserShell /bin/zsh
+    # dscl . -passwd /Users/vagrant vagrant
     # dscl . -append /Groups/admin GroupMembers 00000000-AAAA-BBBB-CCCC-DDDDEEEEFFFF
-    # dscl . -append /Groups/admin GroupMembership user
+    # dscl . -append /Groups/admin GroupMembership vagrant
 else
-    DOMAIN="${VOLUME}/private/var/db/dslocal/nodes/Default/users/user"
+    DOMAIN="${VOLUME}/private/var/db/dslocal/nodes/Default/users/vagrant"
     . ./user.sh
 
     DOMAIN="${VOLUME}/private/var/db/dslocal/nodes/Default/groups/admin"
-    . ./admin.sh
+    . ./group.sh
 fi
+
+DOMAIN="${VOLUME}/Library/Preferences/com.apple.screensaver"
+. ./screensaver_root.sh
 
 DOMAIN="${VOLUME}/Library/Preferences/com.apple.loginwindow"
 . ./loginwindow_root.sh
 
 cp ./kcpassword "${VOLUME}/private/etc/kcpassword"
 
-SUDOER="${VOLUME}/private/etc/sudoers.d/user"
+SUDOER="${VOLUME}/private/etc/sudoers.d/vagrant"
 mkdir -p "$(dirname ${SUDOER})"
-printf 'user\t\tALL = (ALL) NOPASSWD: ALL\n' > "${SUDOER}"
+printf 'vagrant\t\tALL = (ALL) NOPASSWD: ALL\n' > "${SUDOER}"
 
 systemsetup -setsleep Never
 systemsetup -setrestartfreeze off
@@ -51,5 +62,25 @@ cp -f ./logouthook.sh "${LOGOUTHOOK}"
 POWEROFF="${HOME}/.local/bin/poweroff"
 mkdir -p "$(dirname ${POWEROFF})"
 cp -f ./poweroff.applescript "${POWEROFF}"
+
+DOTSSH="$(eval echo ~$(id -un 501))/.ssh"
+mkdir -p "${DOTSSH}"
+chown 501:20 "${DOTSSH}"
+chmod 700 "${DOTSSH}"
+
+AUTHZEDKEYS="${DOTSSH}/authorized_keys"
+cp -f ./authorized_keys "${AUTHZEDKEYS}"
+chown 501:20 "${AUTHZEDKEYS}"
+chmod 600 "${AUTHZEDKEYS}"
+
+IDRSA="${DOTSSH}/id_rsa"
+cp -f ./id_rsa "${IDRSA}"
+chown 501:20 "${IDRSA}"
+chmod 600 "${IDRSA}"
+
+IDRSAPUB="${IDRSA}.pub"
+cp -f ./id_rsa "${IDRSAPUB}"
+chown 501:20 "${IDRSAPUB}"
+chmod 644 "${IDRSAPUB}"
 
 touch "${VOLUME}/private/var/db/.AppleSetupDone"


### PR DESCRIPTION
Per Vagrant's documentation (https://www.vagrantup.com/docs/boxes/base#default-user-settings):
- Rename user `user` to `vagrant`
- Change password `pass` to `vagrant`
- Add insecure Vagrant SSH keys

Other:
- Fix PKG resources' permissions by setting them to `755` instead of `420`
- Fix `loginWindowIdleTime` by moving it from `com.apple.loginwindow` to root's `com.apple.screensaver`
- Disable screensaver with `idleTime` on host's `com.apple.screensaver`