### PR TITLE
SSH Environment Path Helper

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -5,12 +5,11 @@ jobs:
     runs-on: macos-11
     steps:
       - uses: actions/checkout@v2
-      - run: brew install packer skopeo
-      - run: brew install --cask packages vagrant vagrant-vmware-utility vmware-fusion
-      - run: skopeo login -u '${{ github.actor }}' -p '${{ secrets.GITHUB_TOKEN }}' ghcr.io
-      - run: vagrant plugin install vagrant-vmware-desktop
+      - run: brew install --cask packages vmware-fusion
       - run: sudo /Applications/VMware\ Fusion.app/Contents/Library/licenses/vmware-licenseTool enter '${{ secrets.VMWARE_FUSION_SERIAL_NUMBER }}' '' '' '12.0' 'VMware Fusion for Mac OS' ''
       - run: until vctl system start; do :; done;
+      - run: brew install packer skopeo
+      - run: skopeo login -u '${{ github.actor }}' -p '${{ secrets.GITHUB_TOKEN }}' ghcr.io
       - run: make
       - run: make "TAG=$(git describe --dirty --broken --always)" -C oci push
       - run: make "TAG=$(git describe --dirty --broken --always)" -C oci latest

--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -11,6 +11,9 @@ jobs:
       - run: brew install packer skopeo
       - run: skopeo login -u '${{ github.actor }}' -p '${{ secrets.GITHUB_TOKEN }}' ghcr.io
       - run: make
+        env:
+          PACKER_LOG: '1'
+          VAGRANT_LOG: debug
       - run: make "TAG=$(git describe --dirty --broken --always)" -C oci push
       - run: make "TAG=$(git describe --dirty --broken --always)" -C oci latest
         if: github.ref == 'refs/heads/master'

--- a/pkg/MacBox.pkgproj
+++ b/pkg/MacBox.pkgproj
@@ -628,6 +628,22 @@
 						<key>GID</key>
 						<integer>0</integer>
 						<key>PATH</key>
+						<string>build/ssh-environment.sh</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>755</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>0</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
 						<string>build/kcpassword</string>
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
@@ -725,6 +741,22 @@
 						<integer>0</integer>
 						<key>PATH</key>
 						<string>res/setup.sh</string>
+						<key>PATH_TYPE</key>
+						<integer>1</integer>
+						<key>PERMISSIONS</key>
+						<integer>755</integer>
+						<key>TYPE</key>
+						<integer>3</integer>
+						<key>UID</key>
+						<integer>0</integer>
+					</dict>
+					<dict>
+						<key>CHILDREN</key>
+						<array/>
+						<key>GID</key>
+						<integer>0</integer>
+						<key>PATH</key>
+						<string>res/ssh-environment-path-helper.sh</string>
 						<key>PATH_TYPE</key>
 						<integer>1</integer>
 						<key>PERMISSIONS</key>

--- a/pkg/make.py
+++ b/pkg/make.py
@@ -156,6 +156,17 @@ def make_cac():
     return plistlib.dumps(props, fmt=plistlib.FMT_BINARY)
 
 
+def make_cimse():
+    props = {
+        'Disabled': False,
+        'KeepAlive': True,
+        'Label': 'com.incognia.macbox.ssh-environment',
+        'Program': '/private/var/root/.local/bin/ssh-environment-path-helper',
+    }
+
+    return plistlib.dumps(props, fmt=plistlib.FMT_XML)
+
+
 def plist2sh(plist, patch=False):
     value_of = lambda e: switch[type(e)](e)
     
@@ -176,7 +187,7 @@ def plist2sh(plist, patch=False):
             '-dict' + ('-add ' if patch else ' ') + ' '.join(map(lambda kv: f'"{kv[0]}" {value_of(kv[1])}', e.items())),
     }
 
-    props = plistlib.loads(plist, fmt=plistlib.FMT_BINARY)
+    props = plistlib.loads(plist)
 
     sh = b'#!/bin/sh\n'
     for kv in props.items():
@@ -267,6 +278,13 @@ if __name__ == '__main__':
     c_sh = plist2sh(c_plist)
     with open(f'{d}/commerce.sh', 'wb') as f:
         f.write(c_sh)
+
+    se_plist = make_cimse()
+    with open(f'{d}/ssh-environment.plist', 'wb') as f:
+        f.write(se_plist)
+    se_sh = plist2sh(se_plist)
+    with open(f'{d}/ssh-environment.sh', 'wb') as f:
+        f.write(se_sh)
 
     kcpw = make_kcpassword()
     with open(f'{d}/kcpassword', 'wb') as f:

--- a/pkg/res/loginhook.sh
+++ b/pkg/res/loginhook.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -ex
 
-# systemsetup -setremotelogin on
+launchctl load -wF /Library/LaunchDaemons/com.incognia.macbox.ssh-environment.plist
 launchctl load -wF /System/Library/LaunchDaemons/ssh.plist

--- a/pkg/res/poweroff.applescript
+++ b/pkg/res/poweroff.applescript
@@ -1,2 +1,9 @@
 #!/usr/bin/osascript
-tell application "System Events" to shut down without state saving preference
+
+repeat
+	try
+		tell application "System Events"
+			shut down without state saving preference
+		end tell
+	end try
+end repeat

--- a/pkg/res/setup.sh
+++ b/pkg/res/setup.sh
@@ -66,14 +66,33 @@ LOGOUTHOOK="$(defaults read ${DOMAIN} LogoutHook)"
 mkdir -p "$(dirname "${LOGOUTHOOK}")"
 cp -f ./logouthook.sh "${LOGOUTHOOK}"
 
-POWEROFF="${HOME}/.local/bin/poweroff"
-mkdir -p "$(dirname "${POWEROFF}")"
+HOMEBIN="${HOME}/.local/bin"
+mkdir -p "${HOMEBIN}"
+
+POWEROFF="${HOMEBIN}/poweroff"
 cp -f ./poweroff.applescript "${POWEROFF}"
+
+SSHENVIRONMENTPATHHELPER="${HOMEBIN}/ssh-environment-path-helper"
+cp -f ./ssh-environment-path-helper.sh "${SSHENVIRONMENTPATHHELPER}"
+
+DOMAIN="${VOLBASE}/Library/LaunchDaemons/com.incognia.macbox.ssh-environment"
+. ./ssh-environment.sh
+
+ETCSSH="${VOLBASE}/private/etc/ssh"
+
+SSHDCONF="${ETCSSH}/sshd_config"
+sed -Ei '' 's/#(PermitUserEnvironment) .+/\1 yes/g' "${SSHDCONF}"
+
+ENVIRONMENT_ROOT="${ETCSSH}/ssh_environment"
+mkfifo "${ENVIRONMENT_ROOT}"
 
 DOTSSH="$(eval echo ~$(id -un 501))/.ssh"
 mkdir -p "${DOTSSH}"
 chown 501:20 "${DOTSSH}"
 chmod 700 "${DOTSSH}"
+
+ENVIRONMENT_HOME="${DOTSSH}/environment"
+ln -s "${ENVIRONMENT_ROOT}" "${ENVIRONMENT_HOME}"
 
 AUTHZEDKEYS="${DOTSSH}/authorized_keys"
 cp -f ./authorized_keys "${AUTHZEDKEYS}"

--- a/pkg/res/setup.sh
+++ b/pkg/res/setup.sh
@@ -46,6 +46,12 @@ SUDOER="${VOLBASE}/private/etc/sudoers.d/vagrant"
 mkdir -p "$(dirname "${SUDOER}")"
 printf 'vagrant\t\tALL = (ALL) NOPASSWD: ALL\n' > "${SUDOER}"
 
+PATHS="${VOLBASE}/private/etc/paths"
+sed -Ei '' 's|(/usr/bin)|/usr/local/bin\n\1|g' "${PATHS}"
+sed -Ei '' 's|(/usr/sbin)|/usr/local/sbin\n\1|g' "${PATHS}"
+uniq "${PATHS}" "${PATHS}.uniq"
+mv "${PATHS}.uniq" "${PATHS}"
+
 systemsetup -setsleep Never
 systemsetup -setrestartfreeze off
 

--- a/pkg/res/ssh-environment-path-helper.sh
+++ b/pkg/res/ssh-environment-path-helper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -ex
+
+while true
+do
+    /usr/libexec/path_helper -s | sed -e 's/"//g' -e 's/;.*//g' > /private/etc/ssh/ssh_environment
+done

--- a/pkr/macbox.pkr.hcl
+++ b/pkr/macbox.pkr.hcl
@@ -31,7 +31,7 @@ source "vmware-iso" "macbox" {
   ]
 
   # Shutdown configuration
-  shutdown_command = "sudo /var/root/.local/bin/poweroff"
+  shutdown_command = "sudo /private/var/root/.local/bin/poweroff"
 
   # Hardware configuration
   cores                = 1


### PR DESCRIPTION
Use `path_helper` (https://www.manpagez.com/man/8/path_helper/) to generate proper PATH for non-interactive SSH sessions. Enables `PermitUserEnvironment` (https://www.freebsd.org/cgi/man.cgi?sshd_config(5)) on SSH Daemon, makes FIFO `/private/etc/ssh/ssh_environment`, symbolically links it to `~/.ssh/environment`, and creates a LaunchDaemon that produces the correct PATH to the FIFO.